### PR TITLE
Use treesitter to toggle hard wrapping in code comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,22 @@ You have two options:
     `WrappingOpenLog`, and include the relevant sections of the log file that's
     displayed, to help diagnose why `wrapping.nvim` isn't doing what you want.
 
+#### Toggle Hard Wrapping in Comments
+
+This option enables an autocommand which uses treesitter to detect when the
+cursor is in a comment and toggles hard wrapping on and off. This is useful for
+when you want to wrap your code comments to a specific width.
+
+```lua
+    require("wrapping").setup({
+        ...
+        hard_wrap_comments = {
+            notify = false, -- This will override "notify_on_switch"
+            width = 79, -- Default textwidth if not set for the filetype
+        }
+    })
+```
+
 #### Modifying Treesitter Queries (Advanced)
 
 By default, `wrapping.nvim` excludes some lines from the softening calculation

--- a/lua/wrapping/init.lua
+++ b/lua/wrapping/init.lua
@@ -382,7 +382,7 @@ M.setup = function(o)
         },
         notify_on_switch = { opts.notify_on_switch, "boolean" },
         log_path = { opts.log_path, "string" },
-        comment_toggle = { opts.hard_wrap_comments, "table", true}, -- optional
+        comment_toggle = { opts.hard_wrap_comments, "table", true }, -- optional
     })
 
     if

--- a/lua/wrapping/init.lua
+++ b/lua/wrapping/init.lua
@@ -383,7 +383,7 @@ M.setup = function(o)
         },
         notify_on_switch = { opts.notify_on_switch, "boolean" },
         log_path = { opts.log_path, "string" },
-        comment_toggle = { opts.hard_wrap_comments, "table" },
+        comment_toggle = { opts.hard_wrap_comments, "table", true}, -- optional
     })
 
     if

--- a/lua/wrapping/init.lua
+++ b/lua/wrapping/init.lua
@@ -36,11 +36,10 @@ local OPTION_DEFAULTS = {
     },
     notify_on_switch = true,
     log_path = utils.get_log_path(),
-    -- TS query to match comments
-    hard_wrap_comments = {
-        notify = false, -- This will override "notify_on_switch"
-        width = 79, -- Default textwidth if not set for the filetype
-    },
+    -- hard_wrap_comments = {
+    --     notify = false, -- This will override "notify_on_switch"
+    --     width = 79, -- Default textwidth if not set for the filetype
+    -- },
 }
 
 local VERY_LONG_TEXTWIDTH_FOR_SOFT = 999999

--- a/lua/wrapping/treesitter.lua
+++ b/lua/wrapping/treesitter.lua
@@ -90,7 +90,12 @@ M.cursor_in_comment = function()
 
     local node = tsutils.get_node_at_cursor()
 
-    if node and node:type() == "comment" then
+    -- Covers most file-type comments
+    local isComment = node and node:type() == "comment"
+    -- Doc-string comments
+    local isDescription = node and node:type() == "description"
+
+    if isComment or isDescription then
         return true
     end
 

--- a/lua/wrapping/treesitter.lua
+++ b/lua/wrapping/treesitter.lua
@@ -80,4 +80,21 @@ M.count_lines_of_query = function(language, query)
     return total_lines, total_chars
 end
 
+M.cursor_in_comment = function()
+    local tsutils = try_to_load("nvim-treesitter.ts_utils")
+
+    -- For now we just return false if we can't load the module
+    if tsutils == nil then
+        return false
+    end
+
+    local node = tsutils.get_node_at_cursor()
+
+    if node and node:type() == "comment" then
+        return true
+    end
+
+    return false
+end
+
 return M


### PR DESCRIPTION
As I mentioned in #40 I would like to see the ability to auto-wrap code comments. I had a go at implementing this and, whilst it works, I am far from proficient at lua and using neovim's APIs so I wasn't sure how to properly test my implementation.

It's a relatively simple implementation, using `tsutils` to get the node under the cursor and then toggling hard wrap + adding a text width when the cursor is in a comment. I added the following to the options:

```lua
 require("wrapping").setup({
        ...
        hard_wrap_comments = {
            notify = false, -- This will override "notify_on_switch"
            width = 79, -- Default textwidth if not set for the filetype
        }
    })
```

So that it was possible to disable wrap notifications specifically for this mode (and any other in the future!) and allow the user to set their preferred `textwidth` if it is not set in an `ftpluin`.

I left the plugin disabled by default.

Either way, the actual implementation probably needs some refinement, but the logic is there.