### PR TITLE
feat: Add option to manually set detection of nontextual files

### DIFF
--- a/lua/wrapping/init.lua
+++ b/lua/wrapping/init.lua
@@ -167,6 +167,14 @@ local function likely_nontextual_language()
     -- If an LSP provider supports these capabilities it's almost certainly not
     -- a textual language, and therefore we should use hard wrapping
 
+    -- user-provided nontextual detection function or truth value
+    local manual_detector = vim.tbl_get(opts, "nontextual_heuristic")
+    if manual_detector ~= nil and type(manual_detector) == "function" then
+        return manual_detector()
+    elseif manual_detector ~= nil then
+        return manual_detector
+    end
+
     local get_clients
 
     if vim.fn.has("nvim-0.10") == 1 then


### PR DESCRIPTION
Is set in 'nontextual_heuristic' option. Can be boolean value to _always_ return true for detecting nontextual files or false for never detecting them.
Otherwise takes a function which should return a boolean value.

Example for a simple boolean return:

```lua
opts = {
    nontextual_heuristic = false
}
```

This will treat all files as _always_ textual as the heuristic never triggers.

An example for a function override:

```lua
opts = {
    nontextual_heuristic = function()
        if vim.bo.filetype == "djot" then
            return false
        end
        return true
    end
}
```

This treats _all_ djot files _always_ as textual, and _all_ other files as nontextual.

Fixes #49.

This is a very simple implementation of the new option with minimal changes to existing code.
However, there are some additional considerations that I would be happy to change and expand on:

1. Perhaps the option selection code should mimic custom `softener` function overrides more, I would be happy to rewrite such that we have a `get_nontextual_heuristic` function instead which then looks for the override option or retrieves the default.

2. There may be better option names than 'nontextual_heuristic', happy to change.

3. Should we be able to set this per-filetype, also similar to softener? I am not sure if such a change would actually make it _more_ difficult to have a simple configuration, e.g. the default heuristic also works on all filetypes.

4. Lastly, needs to be documented and am happy to do so when there are no other changes expected.


